### PR TITLE
set podMonitor and serviceMonitors not not use label selectors

### DIFF
--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -27,6 +27,10 @@ spec:
     helm:
       skipCrds: true
       values: |-
+        prometheus:
+          prometheusSpec:
+            podMonitorSelectorNilUsesHelmValues: false
+            serviceMonitorSelectorNilUsesHelmValues: false
         grafana:
           # username is 'admin'
           adminPassword: prom-operator


### PR DESCRIPTION
By default, kube-prom-stack will create label selectors that match the helm deployment.  We don't want this because it keeps PodMonitors and ServiceMonitors from being discovered with different labels.