### PR TITLE
feat: adding nginx dashboard

### DIFF
--- a/templates/application-external-nginx.yaml
+++ b/templates/application-external-nginx.yaml
@@ -20,6 +20,10 @@ spec:
           value: '{{ index .Values "argo-cd" "glueops" "ingress_controller_host_port_enabled" }}'
       values: |-
         controller:
+          metrics:
+            enabled: true
+            serviceMonitor:
+              enabled: true
           electionID: external-ingress-nginx-leader
           ingressClassByName: true
           ingressClass: external-ingress-nginx

--- a/templates/application-glueops-grafana-dashboards.yaml
+++ b/templates/application-glueops-grafana-dashboards.yaml
@@ -24,6 +24,6 @@ spec:
   source:
     path: ''
     repoURL: 'https://helm.gpkg.io/platform'
-    targetRevision: 0.1.0
+    targetRevision: 0.2.0
     chart: glueops-grafana-dashboards
   project: glueops-core

--- a/templates/application-internal-nginx.yaml
+++ b/templates/application-internal-nginx.yaml
@@ -20,6 +20,10 @@ spec:
           value: '{{ index .Values "argo-cd" "glueops" "ingress_controller_host_port_enabled" }}'
       values: |-
         controller:
+          metrics:
+            enabled: true
+            serviceMonitor:
+              enabled: true
           electionID: internal-ingress-nginx-leader
           ingressClassByName: true
           ingressClass: internal-ingress-nginx


### PR DESCRIPTION
Prerequisites:

This other PR needs to be merged https://github.com/GlueOps/platform-helm-chart-grafana-dashboards/pull/2 and a v0.2.0 tag needs to be created.

