### PR TITLE
feat/rename-grafana-debezium-dashboard

### DIFF
--- a/templates/application-glueops-grafana-dashboards.yaml
+++ b/templates/application-glueops-grafana-dashboards.yaml
@@ -24,6 +24,6 @@ spec:
   source:
     path: ''
     repoURL: 'https://helm.gpkg.io/platform'
-    targetRevision: 0.3.0
+    targetRevision: 0.4.0
     chart: glueops-grafana-dashboards
   project: glueops-core


### PR DESCRIPTION
feat: upgrading glueops-grafana-dashboards argocd application from v0.3.0 -> v0.4.0
feat: rename Debezium dashboard in Grafana