### PR TITLE
feat: updating glueops-grafana-dashboards to have loki and argocd dashboards

### DIFF
--- a/templates/application-glueops-grafana-dashboards.yaml
+++ b/templates/application-glueops-grafana-dashboards.yaml
@@ -24,6 +24,6 @@ spec:
   source:
     path: ''
     repoURL: 'https://helm.gpkg.io/platform'
-    targetRevision: 0.4.0
+    targetRevision: 0.6.0
     chart: glueops-grafana-dashboards
   project: glueops-core


### PR DESCRIPTION
This version increase includes changes from Bart that were for ArgoCD dashboards