### PR TITLE
Feat/ssl and ingress improvements

### DIFF
--- a/templates/application-external-nginx.yaml
+++ b/templates/application-external-nginx.yaml
@@ -20,6 +20,11 @@ spec:
           value: '{{ index .Values "argo-cd" "glueops" "ingress_controller_host_port_enabled" }}'
       values: |-
         controller:
+          extraArgs:
+            default-ssl-certificate: glueops-core/ingress-nginx-default-certs
+          service:
+            annotations:
+              external-dns.alpha.kubernetes.io/hostname: ingress.{{ .Values.captain_domain }}
           metrics:
             enabled: true
             serviceMonitor:

--- a/templates/application-internal-nginx.yaml
+++ b/templates/application-internal-nginx.yaml
@@ -20,6 +20,11 @@ spec:
           value: '{{ index .Values "argo-cd" "glueops" "ingress_controller_host_port_enabled" }}'
       values: |-
         controller:
+          extraArgs:
+            default-ssl-certificate: glueops-core/ingress-nginx-default-certs
+          service:
+            annotations:
+              external-dns.alpha.kubernetes.io/hostname: internal-ingress.{{ .Values.captain_domain }}
           metrics:
             enabled: true
             serviceMonitor:

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -39,13 +39,8 @@ spec:
             enabled: true
             annotations:
               kubernetes.io/ingress.class: internal-ingress-nginx
-              cert-manager.io/cluster-issuer: glueops-cert-zerossl-prod
             hosts: ['grafana.{{ .Values.captain_domain }}']
             path: "/"
-            tls:
-            - secretName: tls-credential
-              hosts:
-              - grafana.{{ .Values.captain_domain }}
           additionalDataSources:
           - name: Loki
             type: loki

--- a/templates/application-vault.yaml
+++ b/templates/application-vault.yaml
@@ -37,14 +37,9 @@ spec:
           ingress:
               activeService: false
               annotations: 
-                cert-manager.io/cluster-issuer: glueops-cert-zerossl-prod
                 kubernetes.io/ingress.class: internal-ingress-nginx
                 nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
               enabled: true
-              tls:
-                - secretName: vault-ui-tls
-                  hosts:
-                    - vault.{{ .Values.captain_domain }}
               hosts: 
                 - host: vault.{{ .Values.captain_domain }}
               

--- a/templates/certificates.yaml
+++ b/templates/certificates.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ingress-nginx-default-certs
+spec:
+  dnsNames:
+  - '*.apps.{{ .Values.captain_domain }}'
+  - '*.{{ .Values.captain_domain }}'
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: glueops-cert-zerossl-prod
+  secretName: ingress-nginx-default-certs

--- a/templates/customer-configs.yaml
+++ b/templates/customer-configs.yaml
@@ -48,6 +48,12 @@ spec:
   sourceRepos:
   - https://helm.gpkg.io/project-template
   - https://helm.gpkg.io/service
+{{- if .Values.development_mode_enabled }}
+  - https://incubating-helm.gpkg.io/project-template
+  - https://incubating-helm.gpkg.io/service
+  - https://incubating-helm.gpkg.io/platform
+{{- end }}
+
 ---
 apiVersion: v1
 kind: Secret

--- a/values.yaml
+++ b/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-
+development_mode_enabled: false
 captain_domain: nil
 
 glueops_backups:
@@ -91,10 +91,4 @@ argo-cd:
       enabled: true
       hosts: nil
       annotations:
-        cert-manager.io/cluster-issuer: glueops-cert-zerossl-prod
         kubernetes.io/ingress.class: "internal-ingress-nginx"
-      tls: 
-        - 
-          hosts: 
-            - nil
-          secretName: echo-tls


### PR DESCRIPTION
feat: added external-dns annotation to ingress-nginx (internal/external) so thattenant friendly DNS ingress.* and internal-ingress.* are created
feat: also preloaded relevant wildcard SSL certs into nginx so that if a cert isn't provided it will use an existing one if one matches
feat: remove SSL cert creation from argocd, vault, and grafana since nginx provides a matching hostname SSL cert.
feat: add development_mode_enabled with a default of false to the values.yaml so that we can easily toggle dev tooling on/off