### PR TITLE
feat and fixes for grafana credentials and datasources

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Deploy the ArgoCD Platform. This chart is never packaged up but gets used via `h
 | glueops_backups.vault.aws_region | string | `"us-west-2"` | Should be the same `primary_region` you used in: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | glueops_backups.vault.aws_secretKey | string | `"XXXXXXXXXXXXXXXXXXXXXXXXXX"` | Part of `vault_s3_iam_credentials` output from terraform-module-cloud-multy-prerequisites: https://github.com/GlueOps/terraform-module-cloud-multy-prerequisites |
 | glueops_backups.vault.company_key | string | `"<tenant-name-goes-here>"` |  |
+| grafana.admin_password | string | `"glueops-is-awesome"` | Default admin password. CHANGE THIS!!!! |
 | grafana.github_client_id | string | `"XXXXXXXXXXXXXXXXXXXXXXXXXX"` | To create a clientID and clientSecret please reference: https://github.com/GlueOps/github-oauth-apps |
 | grafana.github_client_secret | string | `"XXXXXXXXXXXXXXXXXXXXXXXXXX"` | To create a clientID and clientSecret please reference: https://github.com/GlueOps/github-oauth-apps |
 | grafana.github_other_org_names | string | `"glueops-rocks"` |  |

--- a/templates/application-kube-prometheus-stack.yaml
+++ b/templates/application-kube-prometheus-stack.yaml
@@ -64,6 +64,7 @@ spec:
             podMonitorSelectorNilUsesHelmValues: false
             logLevel: debug
         grafana:
+          adminPassword: "{{ .Values.grafana.admin_password }}"
           ingress:
             enabled: true
             annotations:
@@ -74,16 +75,9 @@ spec:
           - name: Loki
             type: loki
             url: http://loki-read.glueops-core-loki.svc.cluster.local:3100
-          - name: Alertmanager
-            type: alertmanager
-            jsonData:
-              implementation: prometheus
-            url: "http://kube-prometheus-stack-alertmanager.glueops-core-kube-prometheus-stack:9093/"
           grafana.ini:
             server:
               root_url: "https://grafana.{{ .Values.captain_domain }}/"
-            security:
-              disable_initial_admin_creation: true
             auth.github:
                enabled: true
                allow_sign_up: true

--- a/values.yaml
+++ b/values.yaml
@@ -67,6 +67,8 @@ grafana:
   # @ignored
   github_admin_team_name: grafana_super_admins
   github_other_org_names: glueops-rocks
+  # -- Default admin password. CHANGE THIS!!!!
+  admin_password: glueops-is-awesome
 
 
 loki:


### PR DESCRIPTION
fix: remove adding alertmanager as a datasource. It's already built in feat: add admin_password as a value to the Values file for grafana fix: remove disabling admin account creation in grafana. It seems to break the alerts page as well as data source provisioning
feat: add admin_password as a value to the Values file for grafana
fix: remove disabling admin account creation in grafana. It seems to break the alerts page as well as data source provisioning